### PR TITLE
Write attachment comment to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The Tadpoles website and app has several deficiencies which this tries to addres
 - No bulk download functionality
 - Media does not contain EXIF or metadata information on when it was taken
 
+Comments that were posted with the photos are also saved.  If a picture has a comment, you will see a similarly named `txt` file with it.
+
 ## Supported Formats
 
 - PNG

--- a/index.js
+++ b/index.js
@@ -176,7 +176,18 @@ async function maybe_download_attachment(imgkey, event) {
 	
 	if (! fs.existsSync(dirbase + filebase + '.jpg' ) && ! fs.existsSync(dirbase + filebase + '.png' ) && ! fs.existsSync(dirbase + filebase + '.mp4' ) && ! fs.existsSync(dirbase + filebase + '.pdf' )) {
 		console.log('    -- File ' + filebase + ' from ' + event.event_date + ' does not exist... downloading')
-		await mkdirp( dirbase ) 
+		await mkdirp( dirbase, function(err) {
+			if (err != null) {
+				console.error('error calling mkdirp on path: ', dirbase, '\n\ndetails: ', err)
+			}
+		});
+		// save comment to file if it exists
+		var comment = event.comment;
+		if (comment !== undefined && comment !== null && comment !== '') {
+			var commentFileLocation = dirbase + filebase + '.txt'
+			fs.writeFileSync(commentFileLocation, comment)
+		}
+		// download file
 		try {
 			await client.get(imgurl, {
 				responseType: 'arraybuffer',


### PR DESCRIPTION
If it exists, the comment for an image will be written to a similarly named `txt` file.  Added note about this feature to the README file.